### PR TITLE
Make icon flashing configurable

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -53,41 +53,25 @@ chrome.tabs.onUpdated.addListener( ( id, changeInfo, changedTab ) =>
 			|| ( settings.listType == 'disable' && !urlIsAMatch ) )
 		{
 
-			if (settings.flashIcon == 'enable' )
-			{
-				chrome.tabs.executeScript( id, {
-					code: `document.querySelectorAll( 'link[rel*="icon"]' ).forEach( el =>
+			chrome.tabs.executeScript( id, {
+				code: `document.querySelectorAll( 'link[rel*="icon"]' ).forEach( el =>
+					{
+						if ( el.oldHref )
 						{
-							if ( el.oldHref )
-							{
-								return;
-							}
-							el.oldHref = el.href;
-							el.href = "${alertIcon}"
+							return;
+						}
+						el.oldHref = el.href;
+						el.href = "${alertIcon}"
+						if ("${settings.flashIcon}" != 'disable') {
 							let showingOld = false;
 							el.interval = setInterval( () =>
 							{
 								el.href = showingOld ? "${alertIcon}" : el.oldHref;
 								showingOld = !showingOld;
-							}, ${FLASH_INTERVAL_MS} )
-						} );`
-				} )
-			}
-			else
-			{
-				chrome.tabs.executeScript( id, {
-					code: `document.querySelectorAll( 'link[rel*="icon"]' )
-							.forEach( el =>
-							{
-								if ( el.oldHref )
-								{
-									return;
-								}
-								el.oldHref = el.href;
-								el.href = "${alertIcon}";
-							} );`
+							}, ${FLASH_INTERVAL_MS} );
+						}
+					} );`
 				} );
-			}
 		}
 	} );
 } );

--- a/bg.js
+++ b/bg.js
@@ -53,23 +53,41 @@ chrome.tabs.onUpdated.addListener( ( id, changeInfo, changedTab ) =>
 			|| ( settings.listType == 'disable' && !urlIsAMatch ) )
 		{
 
-			chrome.tabs.executeScript( id, {
-				code: `document.querySelectorAll( 'link[rel*="icon"]' ).forEach( el =>
-				{
-					if ( el.oldHref )
-					{
-						return;
-					}
-					el.oldHref = el.href;
-					el.href = "${alertIcon}"
-					let showingOld = false;
-					el.interval = setInterval( () =>
-					{
-						el.href = showingOld ? "${alertIcon}" : el.oldHref;
-						showingOld = !showingOld;
-					}, ${FLASH_INTERVAL_MS} );
-				} )` 
-			} );
+			if (settings.flashIcon == 'enable' )
+			{
+				chrome.tabs.executeScript( id, {
+					code: `document.querySelectorAll( 'link[rel*="icon"]' ).forEach( el =>
+						{
+							if ( el.oldHref )
+							{
+								return;
+							}
+							el.oldHref = el.href;
+							el.href = "${alertIcon}"
+							let showingOld = false;
+							el.interval = setInterval( () =>
+							{
+								el.href = showingOld ? "${alertIcon}" : el.oldHref;
+								showingOld = !showingOld;
+							}, ${FLASH_INTERVAL_MS} )
+						} );`
+				} )
+			}
+			else
+			{
+				chrome.tabs.executeScript( id, {
+					code: `document.querySelectorAll( 'link[rel*="icon"]' )
+							.forEach( el =>
+							{
+								if ( el.oldHref )
+								{
+									return;
+								}
+								el.oldHref = el.href;
+								el.href = "${alertIcon}";
+							} );`
+				} );
+			}
 		}
 	} );
 } );
@@ -91,9 +109,11 @@ chrome.tabs.onActivated.addListener( activeInfo =>
 						{
 							el.href = el.oldHref;
 							delete el.oldHref;
-							clearInterval( el.interval );
+							if ( el.interval ) {
+								clearInterval( el.interval );
+							}
 						}
-					} );` 
+					} );`
 		} );
 	} );
 } );
@@ -108,5 +128,6 @@ function getSettings()
 		listEntries   : '',
 		applyTo       : 'allTabs',
 		alternateIcon : '',
+		flashIcon     : 'enable',
 	}, resolve ) );
 }

--- a/options.html
+++ b/options.html
@@ -68,12 +68,19 @@
 		<textarea placeholder="https://example.com" rows="10" data-savable-name="listEntries"></textarea>
 		<p>Enter one URL per line.</p>
 
-		<label for="applyTo">Enable this extension on...</label>
+		<p><label for="applyTo">Enable this extension on...</label>
 		<select id="applyTo" data-savable-name="applyTo">
 			<option value="allTabs">All tabs</option>
 			<option value="pinnedOnly">Pinned tabs only</option>
 			<option value="unpinnedOnly">Unpinned tabs only</option>
-		</select>
+		</select></p>
+
+		<p><label for="flashIcon">Flash icon when active:</label>
+			<select id="flashIcon" data-savable-name="flashIcon">
+				<option value="enable">Flash when active</option>
+				<option value="disable">Never flash (static icon)</option>
+			</select>
+		</p>
 
 		<label for="alternateIcon">Alternate icon</label>
 		<input id="alternateIcon" placeholder="Paste an image or URL here" type="text" data-savable-name="alternateIcon"/>


### PR DESCRIPTION
I've really found this extension useful, after the loss of the blue-dot feature. Thanks so much for creating it.

Personally, though, I find the flashing to be a little distracting, and feel a static "notification waiting" icon is sufficient for my needs. So, I added a preference to select how the icon is flashed on activation. Currently there are only two options ("enable" and "disable", to switch flashing on/off completely), but in theory the choices could be expanded to allow for control over the speed of the flashing, a certain number of flashes before stopping, etc.

As of this PR it's not _quite_ perfect, because when you change the setting, any existing icons aren't affected — if you disable flashing, any existing flashing icons will continue to flash. And if you enable flashing, only new icons shown after that point will flash. That hasn't bothered me since I only changed the setting once, but I recognize that it could be improved on.

It's certainly possible for `options.js` to update any existing icons whenever the `flashIcon` setting is changed. If I get inspired, or if you think it's necessary for this patch to merge (assuming you're interested at all), I may still go back and add that. It would also be a good opportunity to add flashing to the Preview icon in the options window (when enabled), so that it accurately previewed the current settings.